### PR TITLE
chore: proteger SECRET_KEY mediante variable de entorno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copia este archivo como .env y rellena los valores reales.
+# .env nunca se sube al repositorio.
+
+DJANGO_SECRET_KEY=cambia-esto-por-una-clave-segura

--- a/salud_publica_digital/settings.py
+++ b/salud_publica_digital/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 from os import path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -21,7 +22,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-f0857%(zohy13=%fh)dvywm8f1ehr-#37asmy#_9brw(unj%&6'
+# Leer desde variable de entorno; si no existe usa el valor de desarrollo local
+SECRET_KEY = os.environ.get(
+    'DJANGO_SECRET_KEY',
+    'django-insecure-f0857%(zohy13=%fh)dvywm8f1ehr-#37asmy#_9brw(unj%&6',
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Resumen

Saca la `SECRET_KEY` del repositorio y la mueve a variable de entorno (EDT 4.3 — Configuraciones Adicionales).

## Cambios

- `salud_publica_digital/settings.py`: ahora `SECRET_KEY` se obtiene con `os.environ.get('DJANGO_SECRET_KEY', <valor de desarrollo>)`. El fallback insecure queda sólo para entornos locales sin `.env`.
- `.env.example`: plantilla de referencia que documenta las variables esperadas. Cada desarrollador la copia como `.env` y rellena el valor real.

## Notas

- `.env` ya estaba ignorado por `.gitignore` desde el commit inicial, así que no requiere cambios adicionales.
- En producción se debe definir `DJANGO_SECRET_KEY` con un valor generado con `secrets.token_urlsafe(50)` o equivalente.