### PR TITLE
feat: pantallas iniciales de inicio de sesión y registro

### DIFF
--- a/registro/forms.py
+++ b/registro/forms.py
@@ -1,0 +1,157 @@
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+from consultorio.models import Usuario
+from django import forms
+from re import match
+
+def validate_chilean_dni(rut: str | None) -> bool:
+    """Validate a Chilean RUT.
+    
+    Args:
+        rut: The RUT to validate.
+        
+    Returns:
+        True if the RUT is valid, False otherwise.
+    """
+    if rut is None:
+        return False
+
+    # Clean RUT
+    rut = (
+        rut
+        .replace('.', '')
+        .replace('-', '')
+    )
+    
+    # Check format
+    if not match(r'^\d{7,8}[0-9Kk]$', rut):
+        return False
+    
+    # Split RUT and DV
+    rut_num = int(rut[:-1])
+    dv      = rut[-1].upper()
+    
+    # Calculate DV
+    reversed_digits = map(int, reversed(str(rut_num)))
+    factors         = [2, 3, 4, 5, 6, 7] * 2
+    s               = sum(d * f for d, f in zip(reversed_digits, factors))
+    mod             = (-s) % 11
+    calculated_dv   = 'K' if mod == 10 else str(mod)
+    
+    # Check DV
+    return dv == calculated_dv
+
+def remove_points_and_hyphens(rut: str | None) -> str:
+    """Remove points and hyphens from a RUT.
+    
+    Args:
+        rut: The RUT to clean.
+
+    Returns:
+        The cleaned RUT.
+    """
+    if rut is None:
+        return ''
+    return (
+        rut
+        .replace('.', '')
+        .replace('-', '')
+    )
+    
+def clean_username(self):
+    cleaned_data = self.clean()
+    dni          = cleaned_data.get('username')
+    
+    if not validate_chilean_dni(dni):
+        self.add_error("username", "Ingrese un RUT válido")
+
+    return remove_points_and_hyphens(dni)
+
+
+class RegisterForm(UserCreationForm):
+    
+    class Meta:
+        model = User
+        fields = [
+            "username", 
+            "email", 
+            "first_name",
+            "last_name",
+            "address",
+            "phone",
+            "birthdate",
+        ]
+    
+    username        = forms.CharField(max_length=12)
+    email           = forms.EmailField()
+    first_name      = forms.CharField(max_length=80)
+    last_name       = forms.CharField(max_length=80, required=False)
+    address         = forms.CharField(max_length=255, required=False)
+    phone           = forms.CharField(max_length=15, required=False)
+    birthdate       = forms.DateField(required=False, widget=forms.DateInput(attrs={'type': 'date'}))
+    usable_password = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        # Change labels
+        self.fields["username"].label   = "RUT"
+        self.fields["email"].label      = "Correo"
+        self.fields["first_name"].label = "Nombre"
+        self.fields["last_name"].label  = "Apellido"
+        self.fields["address"].label    = "Dirección"
+        self.fields["phone"].label      = "Teléfono"
+        self.fields["birthdate"].label  = "Fecha de Nacimiento"
+        self.fields["password1"].label  = "Contraseña"
+        self.fields["password2"].label  = "Confirmar contraseña"
+        
+        # Change help texts
+        self.fields["username"].help_text   = "Ingrese su RUT (en un formato válido)"
+        self.fields["email"].help_text      = "Ingrese un correo válido"
+        self.fields["first_name"].help_text = "Ingrese su nombre"
+        self.fields["last_name"].help_text  = "Ingrese su apellido"
+        self.fields["address"].help_text    = "Ingrese su dirección"
+        self.fields["phone"].help_text      = "Ingrese su teléfono"
+        self.fields["birthdate"].help_text  = "Ingrese su fecha de nacimiento"
+        self.fields["password1"].help_text  = "Ingrese una contraseña segura: al menos 8 caracteres, no común y no solo numérica"
+        self.fields["password2"].help_text  = "Repita la contraseña"
+        
+        # Change placeholders
+        self.fields["username"].widget.attrs["placeholder"]   = "RUT"
+        self.fields["email"].widget.attrs["placeholder"]      = "Correo"
+        self.fields["first_name"].widget.attrs["placeholder"] = "Nombre"
+        self.fields["last_name"].widget.attrs["placeholder"]  = "Apellido"
+        self.fields["address"].widget.attrs["placeholder"]    = "Dirección"
+        self.fields["phone"].widget.attrs["placeholder"]      = "Teléfono"
+        self.fields["birthdate"].widget.attrs["placeholder"]  = "Fecha de Nacimiento"
+        self.fields["password1"].widget.attrs["placeholder"]  = "Contraseña"
+        self.fields["password2"].widget.attrs["placeholder"]  = "Confirmar contraseña"
+        
+        # Change error messages
+        self.fields["username"].error_messages = {
+            "unique"   : "Este RUT ya está registrado",
+            "invalid"  : "Ingrese un RUT válido",
+            "required" : "Este campo es obligatorio"
+        }
+        
+        self.fields["email"].error_messages = {
+            "unique"   : "Este correo ya está registrado",
+            "invalid"  : "Ingrese un correo válido",
+            "required" : "Este campo es obligatorio"
+        }
+        
+        self.fields["first_name"].error_messages = {
+            "required" : "Este campo es obligatorio"
+        }
+
+        self.fields["password1"].error_messages = {
+            "required" : "Este campo es obligatorio",
+            "password_too_short" : "La contraseña es muy corta",
+        }
+        
+        self.fields["password2"].error_messages = {
+            "required" : "Este campo es obligatorio",
+            "password_mismatch" : "Las contraseñas no coinciden"
+        }
+        
+        self.error_messages["password_mismatch"] = "Las contraseñas no coinciden."

--- a/registro/templates/registration/login.html
+++ b/registro/templates/registration/login.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+    {% block extra_css %}
+        <link rel="stylesheet" href="{% static 'css/login.css' %}" rel="stylesheet"/> 
+    {% endblock %}
+
+    {% block title %}
+        Registro
+    {% endblock %}
+
+    {% block navbar %} 
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'principal:principal' %}">Página principal</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'registro' %}">Registrarse</a>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" href="#">Iniciar sesión</a>
+            </li>
+        </ul>
+    {% endblock %}
+
+    {% block content %}
+    <div class="login-page">
+        <div class="form">
+          <form method="POST" action="">
+            {% csrf_token %}
+            <h3 class="login-title">INICIA SESIÓN</h3>
+            <div class="input-group mb-3">
+              <input type="text" name="username" placeholder="Usuario..." class="form-control">
+            </div>
+            <div class="input-group mb-2">
+                <input type="password" name="password" placeholder="Contraseña..." class="form-control" >
+            </div>
+            <p class="message">¿No te has registrado? <a href="{% url 'registro' %}">Regístrate con tu Clave Única</a></p>
+            <p class="message">¿Olvidaste tu contraseña? <a href="{% url 'registro' %}">Recupérala con tu Clave Única</a></p>
+            <button type="submit"> ENVIAR </button>
+          </form>
+      {% for message in messages %}
+         <p class= "text-center">{{message}}</p>
+      {% endfor %}
+        </div>
+      </div>
+    {% endblock %}

--- a/registro/templates/registro.html
+++ b/registro/templates/registro.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+    {% block title %} 
+        Crea tu cuenta con tu RUT
+    {% endblock %}
+
+    {% block navbar %} 
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'principal:principal' %}">Página principal</a>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" href="{% url 'registro' %}">Registrarse</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'login' %}">Iniciar sesión</a>
+            </li>
+        </ul>
+    {% endblock %}
+
+    {% block extra_css %} 
+        <link rel="stylesheet" href="{% static 'css/form.css' %}" rel="stylesheet"/> 
+        <link rel="stylesheet" href="{% static 'css/principal.css' %}" rel="stylesheet"/> 
+    {% endblock %}
+
+    {% block content %} 
+        <form method="POST" class="form-group">
+            {% csrf_token %}
+            {{form|crispy}}
+            <button type="submit" class="btn btn-primary">Registrarse</button>
+        </form>
+    {% endblock %}

--- a/registro/views.py
+++ b/registro/views.py
@@ -1,0 +1,37 @@
+from django.shortcuts import render, redirect
+from django.contrib.auth import login, authenticate
+from .forms import RegisterForm
+
+# Create your views here.
+def registro(request):
+    
+    if request.method == "POST":
+        
+        form = RegisterForm(request.POST)
+        
+        if form.is_valid():
+            
+            user = form.save()
+            raw_password = form.cleaned_data.get("password1")
+            user = authenticate(
+                username = user.username, 
+                password = raw_password
+            )
+            login(request, user)
+            
+            return redirect("/")
+        
+        else:
+            print(form.errors)
+            
+    else:
+        form = RegisterForm()
+        
+    return render(
+        request = request, 
+        template_name = "registro.html", 
+        context = {
+            "form": form,
+            "title": "Registro de pacientes"
+        }
+    )

--- a/salud_publica_digital/settings.py
+++ b/salud_publica_digital/settings.py
@@ -135,3 +135,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 CRISPY_TEMPLATE_PACK = "bootstrap5"
+
+# Login redirect
+LOGIN_REDIRECT_URL = "/"
+# Logout redirect
+LOGOUT_REDIRECT_URL = "/"

--- a/salud_publica_digital/urls.py
+++ b/salud_publica_digital/urls.py
@@ -17,7 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+from registro import views as registro_views
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('principal.urls')),
+    path('registro/', registro_views.registro, name='registro'),
+    path('', include('django.contrib.auth.urls')),
 ]


### PR DESCRIPTION
## Resumen

Pantallas iniciales del flujo de autenticación: registro y login (EDT 4.5 — Desarrollo Frontend, primera iteración).

## Cambios

- `registro/forms.py`: `RegisterForm` extiende `UserCreationForm` con todos los campos del flujo chileno: RUT (en `username`), correo, nombre, apellido, dirección, teléfono y fecha de nacimiento. Incluye labels, placeholders y mensajes de error en español. Trae helpers `validate_chilean_dni` y `remove_points_and_hyphens` listos para usar en la integración del backend (siguiente PR de RUT).
- `registro/views.py`: vista `registro` que valida el form, guarda al usuario, lo autentica con `authenticate()` y lo redirige a `/`.
- `registro/templates/registro.html`: pantalla de registro con `{{ form|crispy }}` y navbar contextual.
- `registro/templates/registration/login.html`: pantalla de login con campos de RUT y contraseña, links a registro y mensajes de error.
- `salud_publica_digital/urls.py`: se incorpora `/registro/` y se incluyen las URLs estándar de `django.contrib.auth` (login, logout, password reset).
- `salud_publica_digital/settings.py`: `LOGIN_REDIRECT_URL` y `LOGOUT_REDIRECT_URL` apuntan al home.

## Notas

- En este PR la validación de RUT está disponible como helper pero aún no se aplica al `clean_username`. La integración completa del flujo RUT (backend de autenticación, creación de Paciente/Profesional, layout crispy con `tipo`) llega en el PR que cierra el issue #1.
- Las plantillas de password reset (issue #7, `estado:pendiente`) no se incluyen en esta entrega.