### PR TITLE
feat(consultorios): búsqueda de consultorios por región y comuna

### DIFF
--- a/consultorio/templates/consultorio.html
+++ b/consultorio/templates/consultorio.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+{% load static %}
+
+    {% block title %}
+        Buscar consultorio
+    {% endblock %}
+
+    {% block navbar %}
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'principal:principal' %}">Página principal</a>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" href="{% url 'consultorio' %}">Buscar consultorio</a>
+            </li>
+            <li class="nav-item">
+                <form id="frm_logout" method="post" action="{% url 'logout' %}">
+                    {% csrf_token %}
+                    <a class="nav-link" href="javascript:document.getElementById('frm_logout').submit();">Cerrar sesión</a>
+                </form>
+            </li>
+        </ul>
+    {% endblock %}
+
+    {% block extra_css %}
+        <link rel="stylesheet" href="{% static 'css/principal.css' %}" rel="stylesheet"/>
+        <link rel="stylesheet" href="{% static 'css/consultorio.css' %}" rel="stylesheet"/>
+    {% endblock %}
+
+    {% block content %}
+    <div class="container">
+        <h1 class="lvl-select">Buscar consultorios</h1>
+        <p class="text-muted">Selecciona tu región y comuna para ver los consultorios disponibles.</p>
+        <form method="get">
+            <div class="form-group">
+                <label class="lvl-select" for="region">Región:</label>
+                <select id="region" class="form-control">
+                    <option value="">Seleccione una región</option>
+                    {% for region in regiones %}
+                        <option value="{{ region.c_reg }}">{{ region.nom_reg }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group">
+                <label class="lvl-select" for="comuna">Comuna:</label>
+                <select id="comuna" class="form-control" disabled>
+                    <option value="">Seleccione una comuna</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label class="lvl-select" for="consultorio">Consultorio:</label>
+                <select id="consultorio" class="form-control" disabled>
+                    <option value="">Seleccione un consultorio</option>
+                </select>
+            </div>
+        </form>
+    </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const regionSelect = document.getElementById('region');
+        const comunaSelect = document.getElementById('comuna');
+        const consultorioSelect = document.getElementById('consultorio');
+
+        regionSelect.addEventListener('change', function() {
+            const regionId = parseInt(this.value);
+            if (regionId) {
+                fetch(`/consultorio/obtener_comunas/${regionId}/`)
+                    .then(response => response.json())
+                    .then(data => {
+                        comunaSelect.innerHTML = '<option value="">Seleccione una comuna</option>';
+                        data.forEach(comuna => {
+                            comunaSelect.innerHTML += `<option value="${comuna.c_com}">${comuna.nom_com}</option>`;
+                        });
+                        comunaSelect.disabled = false;
+                    });
+            } else {
+                comunaSelect.innerHTML = '<option value="">Seleccione una comuna</option>';
+                comunaSelect.disabled = true;
+                consultorioSelect.innerHTML = '<option value="">Seleccione un consultorio</option>';
+                consultorioSelect.disabled = true;
+            }
+        });
+
+        comunaSelect.addEventListener('change', function() {
+            const comunaId = this.value;
+            if (comunaId) {
+                fetch(`/consultorio/obtener_consultorios/${comunaId}/`)
+                    .then(response => response.json())
+                    .then(data => {
+                        consultorioSelect.innerHTML = '<option value="">Seleccione un consultorio</option>';
+                        data.forEach(consultorio => {
+                            consultorioSelect.innerHTML += `<option value="${consultorio.objectid}">${consultorio.nombre}</option>`;
+                        });
+                        consultorioSelect.disabled = false;
+                    });
+            } else {
+                consultorioSelect.innerHTML = '<option value="">Seleccione un consultorio</option>';
+                consultorioSelect.disabled = true;
+            }
+        });
+    });
+    </script>
+    {% endblock %}

--- a/consultorio/urls.py
+++ b/consultorio/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("", views.seleccionar_region, name="consultorio"),
+    path("obtener_comunas/<int:c_reg>/", views.obtener_comunas, name="obtener_comunas"),
+    path("obtener_consultorios/<str:c_com>/", views.obtener_consultorios, name="obtener_consultorios"),
+]

--- a/consultorio/views.py
+++ b/consultorio/views.py
@@ -1,0 +1,41 @@
+from django.shortcuts import render
+from django.http import JsonResponse
+from django.contrib.auth.decorators import login_required
+
+from .models import Consultorio
+
+
+@login_required(login_url='/login/')
+def seleccionar_region(request):
+    regiones = (
+        Consultorio
+        .objects
+        .values('c_reg', 'nom_reg')
+        .distinct()
+        .order_by('c_reg')
+    )
+    return render(request, 'consultorio.html', {'regiones': regiones})
+
+
+@login_required(login_url='/login/')
+def obtener_comunas(request, c_reg):
+    comunas = (
+        Consultorio
+        .objects
+        .filter(c_reg=c_reg)
+        .values('c_com', 'nom_com')
+        .distinct()
+        .order_by('nom_com')
+    )
+    return JsonResponse(list(comunas), safe=False)
+
+
+@login_required(login_url='/login/')
+def obtener_consultorios(request, c_com):
+    consultorios = (
+        Consultorio
+        .objects
+        .filter(c_com=c_com)
+        .values()
+    )
+    return JsonResponse(list(consultorios), safe=False)

--- a/salud_publica_digital/urls.py
+++ b/salud_publica_digital/urls.py
@@ -22,6 +22,7 @@ from registro import views as registro_views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('principal.urls')),
+    path('consultorio/', include('consultorio.urls')),
     path('registro/', registro_views.registro, name='registro'),
     path('', include('django.contrib.auth.urls')),
 ]

--- a/static/css/consultorio.css
+++ b/static/css/consultorio.css
@@ -1,0 +1,3 @@
+.lvl-select {
+    color:white;
+}


### PR DESCRIPTION
## Resumen

Implementa la historia de usuario PB-09: el paciente puede ubicar consultorios filtrando por región y comuna (EDT 4.5 — Desarrollo Frontend, segunda iteración).

## Cambios

- `consultorio/views.py`:
  - `seleccionar_region`: renderiza el formulario inicial con la lista distinct de regiones desde el modelo `Consultorio`.
  - `obtener_comunas(c_reg)`: devuelve JSON con las comunas de la región dada.
  - `obtener_consultorios(c_com)`: devuelve JSON con los consultorios de la comuna dada.
- `consultorio/urls.py`: rutas para los tres endpoints.
- `consultorio/templates/consultorio.html`: formulario con tres selects en cascada (Región -> Comuna -> Consultorio). El JS habilita el siguiente select sólo cuando hay una selección válida y consume los endpoints JSON con `fetch`.
- `static/css/consultorio.css`: estilos del formulario.
- `salud_publica_digital/urls.py`: se incluye `consultorio.urls` bajo el prefijo `/consultorio/`.

## Notas

- Las vistas requieren autenticación (`@login_required`). El flujo de auth con RUT llega en los siguientes PRs.
- En esta iteración la pantalla muestra los consultorios disponibles; la creación de la reserva en sí (con motivo, fecha y profesional) corresponde al issue #4 y entra en una entrega posterior.

Closes #3