### PR TITLE
feat(auth): pulido de UX en el formulario de registro

### DIFF
--- a/registro/forms.py
+++ b/registro/forms.py
@@ -95,7 +95,11 @@ class RegisterForm(UserCreationForm):
     last_name       = forms.CharField(max_length=80, required=False)
     address         = forms.CharField(max_length=255, required=False)
     phone           = forms.CharField(max_length=15, required=False)
-    birthdate       = forms.DateField(required=False, widget=forms.DateInput(attrs={'type': 'date'}))
+    birthdate       = forms.DateField(
+                        required=False,
+                        input_formats=['%d / %m / %Y', '%d/%m/%Y', '%Y-%m-%d'],
+                        widget=forms.TextInput(),
+                    )
     tipo            = forms.ChoiceField(choices=TIPO_CHOICES, initial='paciente')
     especialidad    = forms.CharField(max_length=255, required=False)
     usable_password = None
@@ -114,27 +118,30 @@ class RegisterForm(UserCreationForm):
         self.fields["password1"].label  = "Contraseña"
         self.fields["password2"].label  = "Confirmar contraseña"
         
-        # Change help texts
-        self.fields["username"].help_text   = "Ingrese su RUT (en un formato válido)"
-        self.fields["email"].help_text      = "Ingrese un correo válido"
-        self.fields["first_name"].help_text = "Ingrese su nombre"
-        self.fields["last_name"].help_text  = "Ingrese su apellido"
-        self.fields["address"].help_text    = "Ingrese su dirección"
-        self.fields["phone"].help_text      = "Ingrese su teléfono"
-        self.fields["birthdate"].help_text  = "Ingrese su fecha de nacimiento"
-        self.fields["password1"].help_text  = "Ingrese una contraseña segura: al menos 8 caracteres, no común y no solo numérica"
-        self.fields["password2"].help_text  = "Repita la contraseña"
-        
-        # Change placeholders
-        self.fields["username"].widget.attrs["placeholder"]   = "RUT"
-        self.fields["email"].widget.attrs["placeholder"]      = "Correo"
-        self.fields["first_name"].widget.attrs["placeholder"] = "Nombre"
-        self.fields["last_name"].widget.attrs["placeholder"]  = "Apellido"
-        self.fields["address"].widget.attrs["placeholder"]    = "Dirección"
-        self.fields["phone"].widget.attrs["placeholder"]      = "Teléfono"
-        self.fields["birthdate"].widget.attrs["placeholder"]  = "Fecha de Nacimiento"
-        self.fields["password1"].widget.attrs["placeholder"]  = "Contraseña"
-        self.fields["password2"].widget.attrs["placeholder"]  = "Confirmar contraseña"
+        # Help texts: solo donde hay una regla real que comunicar
+        self.fields["username"].help_text   = "Ej: 12.345.678-9"
+        self.fields["email"].help_text      = ""
+        self.fields["first_name"].help_text = ""
+        self.fields["last_name"].help_text  = ""
+        self.fields["address"].help_text    = ""
+        self.fields["phone"].help_text      = ""
+        self.fields["birthdate"].help_text  = ""
+        self.fields["password1"].help_text  = "Mínimo 8 caracteres, sin secuencias obvias ni solo números"
+        self.fields["password2"].help_text  = ""
+
+        # Placeholders: ejemplos concretos, no repetir el label
+        self.fields["username"].widget.attrs["placeholder"]   = "12.345.678-9"
+        self.fields["email"].widget.attrs["placeholder"]      = "ejemplo@correo.com"
+        self.fields["first_name"].widget.attrs["placeholder"] = "María"
+        self.fields["last_name"].widget.attrs["placeholder"]  = "González"
+        self.fields["address"].widget.attrs["placeholder"]    = "Av. Principal 123, Santiago"
+        self.fields["phone"].widget.attrs["placeholder"]      = "+56 9 1234 5678"
+        self.fields["birthdate"].widget.attrs["placeholder"]   = "DD / MM / AAAA"
+        self.fields["birthdate"].widget.attrs["maxlength"]     = "14"
+        self.fields["birthdate"].widget.attrs["inputmode"]     = "numeric"
+        self.fields["birthdate"].widget.attrs["autocomplete"]  = "bday"
+        self.fields["password1"].widget.attrs["placeholder"]  = "Mínimo 8 caracteres"
+        self.fields["password2"].widget.attrs["placeholder"]  = "Repite tu contraseña"
         
         # Change error messages
         self.fields["username"].error_messages = {
@@ -189,7 +196,6 @@ class RegisterForm(UserCreationForm):
             Field('phone',      css_class='login-input'),
             Field('birthdate',  css_class='login-input'),
             Field('password1',  css_class='login-input'),
-            HTML('<p class="text-muted small mb-2">Mínimo 8 caracteres</p>'),
             Field('password2',  css_class='login-input'),
         )
 

--- a/registro/templates/registro.html
+++ b/registro/templates/registro.html
@@ -70,12 +70,39 @@
 
 {% block extra_js %}
 <script>
-  const tipo = document.getElementById('id_tipo');
+document.addEventListener('DOMContentLoaded', function () {
+
+  // ── Toggle especialidad ──────────────────────────────────────────────
+  const tipo   = document.getElementById('id_tipo');
   const divEsp = document.getElementById('div-especialidad');
-  function toggleEspecialidad() {
-    divEsp.style.display = tipo.value === 'profesional' ? '' : 'none';
+  if (tipo && divEsp) {
+    function toggleEspecialidad() {
+      divEsp.style.display = tipo.value === 'profesional' ? '' : 'none';
+    }
+    toggleEspecialidad();
+    tipo.addEventListener('change', toggleEspecialidad);
   }
-  toggleEspecialidad();
-  tipo.addEventListener('change', toggleEspecialidad);
+
+  // ── Auto-formato fecha de nacimiento (DD / MM / AAAA) ────────────────
+  const bdInput = document.getElementById('id_birthdate')
+               || document.querySelector('input[name="birthdate"]');
+
+  function formatearFecha(raw) {
+    const digits = raw.replace(/\D/g, '').slice(0, 8);
+    if (digits.length <= 2) return digits;
+    if (digits.length <= 4) return digits.slice(0, 2) + ' / ' + digits.slice(2);
+    return digits.slice(0, 2) + ' / ' + digits.slice(2, 4) + ' / ' + digits.slice(4);
+  }
+
+  if (bdInput) {
+    ['input', 'change'].forEach(function (evt) {
+      bdInput.addEventListener(evt, function () {
+        const formatted = formatearFecha(this.value);
+        if (this.value !== formatted) this.value = formatted;
+      });
+    });
+  }
+
+});
 </script>
 {% endblock %}

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -10,36 +10,43 @@
 
 /* ── Tabs ── */
 .login-tabs {
-  background-color: #F0F0F5;
+  background-color: rgba(0, 0, 0, 0.06);
   border-radius: 7px;
   padding: 4px;
 }
 
 .login-tabs .nav-link {
-  border-radius: 7px;
-  color: #333;
+  border-radius: 5px;
+  color: #555;
   font-weight: 600;
   font-size: 0.95rem;
-  transition: background 0.2s;
+  transition: background 0.15s, color 0.15s;
 }
 
+/* Hover: pista visual de que la pestaña inactiva es clicable */
+.login-tabs .nav-link:not(.active):hover {
+  background-color: rgba(255, 255, 255, 0.45);
+  color: #222;
+}
+
+/* Activa: "levantada" con sombra suave → la inactiva parece hundida */
 .login-tabs .nav-link.active {
   background-color: #fff;
   color: #000;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 /* ── Inputs ── */
 .login-input {
-  background-color: #F0F0F5;
-  border: none;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
   border-radius: 7px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  box-shadow: none;
   height: 38px;
 }
 
 .login-input:focus {
-  background-color: #F0F0F5;
+  background-color: #fff;
   border-color: #2B7FFF;
   box-shadow: 0 0 0 3px rgba(43, 127, 255, 0.15);
 }


### PR DESCRIPTION
## Resumen

Refinamientos de UX sobre el formulario de registro al cierre de la fase de Desarrollo Backend (EDT 4.6).

## Cambios

- **`registro/forms.py`**:
  - El campo `birthdate` deja de ser `DateInput type=date` (que se renderiza distinto en cada navegador) y pasa a un `TextInput` con `input_formats=['%d / %m / %Y', '%d/%m/%Y', '%Y-%m-%d']`. En móvil aparece teclado numérico gracias a `inputmode="numeric"`.
  - Placeholders más concretos: `12.345.678-9` para RUT, `ejemplo@correo.com` para correo, `María` para nombre, etc., en vez de repetir el label.
  - `help_texts` depurados: sólo se mantienen donde hay una regla útil (formato del RUT, mínimo del password). Los demás quedan vacíos.
- **`registro/templates/registro.html`**: JS que se ejecuta en `DOMContentLoaded` y formatea sobre la marcha el campo `birthdate` (inserta los `/` y limita a 8 dígitos). El toggle de especialidad se mantiene.
- **`static/css/login.css`**: unifica el estilo de inputs entre login y registro (fondo blanco con borde) y refina la pestaña activa con sombra sutil.

## Notas

- El flujo de recuperación de contraseña (issue #7) y su enlace en login quedan **fuera** de esta entrega. Cuando ese issue se aborde, se incorporarán los templates de password reset y el enlace correspondiente.