### PR TITLE
feat(reservas): pantallas iniciales de mis horas, reserva y cancelación

### DIFF
--- a/consultorio/templates/cancelar_hora.html
+++ b/consultorio/templates/cancelar_hora.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Cancelar hora — Consultorio Digital{% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/principal.css' %}"/>
+  <link rel="stylesheet" href="{% static 'css/consultorio.css' %}"/>
+{% endblock %}
+
+{% block navbar %}
+  <ul class="navbar-nav me-auto gap-lg-1">
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'principal:principal' %}">Inicio</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'mis_horas' %}">Mis horas</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'consultorio' %}">Reservar hora</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white active" href="{% url 'cancelar_hora' %}">Cancelar hora</a>
+    </li>
+  </ul>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-12 col-md-8 col-lg-6">
+
+    <div class="card border-0 shadow-sm rounded-3">
+      <div class="card-body p-4 p-md-5">
+
+        <div class="d-flex align-items-center gap-3 mb-1">
+          <i class="bi bi-calendar-x fs-3 text-danger"></i>
+          <h4 class="fw-light mb-0">Cancelar cita</h4>
+        </div>
+        <p class="text-muted small mb-4">
+          Cancela con al menos 24 horas de anticipación para liberar el horario a otros pacientes.
+        </p>
+
+        {# PASO 1 — Seleccionar cita #}
+        {% if not reserva_seleccionada %}
+
+          {% if reservas_activas %}
+            <p class="fw-semibold mb-3">Selecciona la cita que deseas cancelar:</p>
+            <form method="post">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="seleccionar">
+              <div class="d-flex flex-column gap-3 mb-4">
+                {% for reserva in reservas_activas %}
+                <label class="reserva-opcion border rounded-3 p-3 d-flex align-items-start gap-3" style="cursor:pointer;">
+                  <input type="radio" name="reserva_id" value="{{ reserva.id }}" class="form-check-input mt-1" required>
+                  <div class="flex-grow-1">
+                    <div class="fw-semibold">{{ reserva.consultorio.nombre }}</div>
+                    {% if reserva.profesional %}
+                      <div class="small text-muted">
+                        <i class="bi bi-person-badge me-1"></i>
+                        Dr/a. {{ reserva.profesional.usuario.nombre }} {{ reserva.profesional.usuario.apellido }}
+                      </div>
+                    {% endif %}
+                    <div class="small text-muted">
+                      <i class="bi bi-calendar3 me-1"></i>{{ reserva.fecha_reserva|date:"d/m/Y" }}
+                      &nbsp;<i class="bi bi-clock me-1"></i>{{ reserva.fecha_reserva|date:"H:i" }}
+                    </div>
+                    <div class="small text-muted fst-italic">{{ reserva.motivo }}</div>
+                  </div>
+                  {% if reserva.estado == "confirmada" %}
+                    <span class="badge badge-estado bg-confirmado ms-auto align-self-center">Confirmada</span>
+                  {% else %}
+                    <span class="badge badge-estado bg-pendiente ms-auto align-self-center">Pendiente</span>
+                  {% endif %}
+                </label>
+                {% endfor %}
+              </div>
+              <button type="submit" class="btn btn-danger w-100">Continuar</button>
+            </form>
+
+          {% else %}
+            <div class="text-center text-muted py-4">
+              <i class="bi bi-calendar-check fs-3 d-block mb-2"></i>
+              No tienes citas activas para cancelar.
+            </div>
+          {% endif %}
+
+        {# PASO 2 — Confirmar con código #}
+        {% else %}
+
+          {# Resumen de la cita seleccionada #}
+          <div class="border rounded-3 p-3 mb-4 bg-light">
+            <div class="fw-semibold">{{ reserva_seleccionada.consultorio.nombre }}</div>
+            {% if reserva_seleccionada.profesional %}
+              <div class="small text-muted">
+                <i class="bi bi-person-badge me-1"></i>
+                Dr/a. {{ reserva_seleccionada.profesional.usuario.nombre }} {{ reserva_seleccionada.profesional.usuario.apellido }}
+              </div>
+            {% endif %}
+            <div class="small text-muted">
+              <i class="bi bi-calendar3 me-1"></i>{{ reserva_seleccionada.fecha_reserva|date:"d/m/Y" }}
+              &nbsp;<i class="bi bi-clock me-1"></i>{{ reserva_seleccionada.fecha_reserva|date:"H:i" }}
+            </div>
+          </div>
+
+          {# Caja del código de cancelación #}
+          <div class="rounded-3 p-3 mb-4 text-center" style="background:#FFF3CD; border: 1px solid #FFE08A;">
+            <div class="small text-muted mb-1">
+              <i class="bi bi-shield-lock me-1"></i>Código de cancelación
+            </div>
+            <div class="fw-bold fs-2 letter-spacing-wide" id="codigo-display" style="letter-spacing: 0.25em;">
+              {{ codigo_generado }}
+            </div>
+            <div class="small text-muted mt-1">
+              Ingresa este código para confirmar la cancelación.
+            </div>
+          </div>
+
+          {# Error de código incorrecto #}
+          {% if codigo_incorrecto %}
+          <div class="alert alert-danger py-2 small mb-3 d-flex align-items-center gap-2">
+            <i class="bi bi-x-circle-fill"></i>
+            El código ingresado no es correcto. Inténtalo de nuevo.
+          </div>
+          {% endif %}
+
+          <form method="post" action="{% url 'cancelar_hora' %}">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="confirmar">
+            <input type="hidden" name="confirmar_reserva_id" value="{{ reserva_seleccionada.id }}">
+
+            <div class="mb-3">
+              <label class="form-label fw-semibold" for="codigo">Código de confirmación</label>
+              <input
+                type="text"
+                id="codigo"
+                name="codigo"
+                class="form-control reserva-input {% if codigo_incorrecto %}is-invalid{% endif %}"
+                placeholder="Ingresa el código de 6 dígitos"
+                maxlength="6"
+                autocomplete="off"
+              />
+            </div>
+
+            <div class="mb-4">
+              <label class="form-label fw-semibold" for="motivo_cancelacion">Motivo de cancelación <span class="text-muted fw-normal">(opcional)</span></label>
+              <input
+                type="text"
+                id="motivo_cancelacion"
+                name="motivo_cancelacion"
+                class="form-control reserva-input"
+                placeholder="¿Por qué necesitas cancelar?"
+              />
+            </div>
+
+            <div class="d-flex gap-2">
+              <button type="submit" class="btn btn-outline-secondary w-50"
+                form="frm-volver">← Volver</button>
+              <button type="submit" class="btn btn-danger w-50">Confirmar cancelación</button>
+            </div>
+          </form>
+
+          <form id="frm-volver" method="post" action="{% url 'cancelar_hora' %}">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="limpiar">
+          </form>
+
+        {% endif %}
+
+      </div>
+    </div>
+
+  </div>
+</div>
+{% endblock %}

--- a/consultorio/templates/consultorio.html
+++ b/consultorio/templates/consultorio.html
@@ -1,104 +1,287 @@
 {% extends "base.html" %}
 {% load static %}
 
-    {% block title %}
-        Buscar consultorio
-    {% endblock %}
+{% block title %}Reservar hora — Consultorio Digital{% endblock %}
 
-    {% block navbar %}
-        <ul class="navbar-nav">
-            <li class="nav-item">
-                <a class="nav-link" href="{% url 'principal:principal' %}">Página principal</a>
-            </li>
-            <li class="nav-item active">
-                <a class="nav-link" href="{% url 'consultorio' %}">Buscar consultorio</a>
-            </li>
-            <li class="nav-item">
-                <form id="frm_logout" method="post" action="{% url 'logout' %}">
-                    {% csrf_token %}
-                    <a class="nav-link" href="javascript:document.getElementById('frm_logout').submit();">Cerrar sesión</a>
-                </form>
-            </li>
-        </ul>
-    {% endblock %}
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/consultorio.css' %}"/>
+{% endblock %}
 
-    {% block extra_css %}
-        <link rel="stylesheet" href="{% static 'css/principal.css' %}" rel="stylesheet"/>
-        <link rel="stylesheet" href="{% static 'css/consultorio.css' %}" rel="stylesheet"/>
-    {% endblock %}
+{% block navbar %}
+  <ul class="navbar-nav me-auto gap-lg-1">
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'principal:principal' %}">Inicio</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'mis_horas' %}">Mis horas</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white active" href="{% url 'consultorio' %}">Reservar hora</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'cancelar_hora' %}">Cancelar hora</a>
+    </li>
+  </ul>
+{% endblock %}
 
-    {% block content %}
-    <div class="container">
-        <h1 class="lvl-select">Buscar consultorios</h1>
-        <p class="text-muted">Selecciona tu región y comuna para ver los consultorios disponibles.</p>
-        <form method="get">
-            <div class="form-group">
-                <label class="lvl-select" for="region">Región:</label>
-                <select id="region" class="form-control">
-                    <option value="">Seleccione una región</option>
-                    {% for region in regiones %}
-                        <option value="{{ region.c_reg }}">{{ region.nom_reg }}</option>
-                    {% endfor %}
-                </select>
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-12 col-md-10 col-lg-7 col-xl-6">
+
+    <div class="card border-0 shadow-sm reserva-card">
+      <div class="card-body p-4 p-md-5">
+
+        <div class="d-flex align-items-center gap-3 mb-4">
+          <i class="bi bi-calendar2-plus fs-3 text-dark"></i>
+          <div>
+            <h4 class="fw-bold mb-0">Agenda tu cita</h4>
+            <p class="text-muted small mb-0">Selecciona ubicación, doctor y horario disponible</p>
+          </div>
+        </div>
+
+        <form method="post" id="frm-reserva">
+          {% csrf_token %}
+
+          {# ── Región ── #}
+          <div class="mb-3">
+            <label class="form-label reserva-label" for="region">Región</label>
+            <select id="region" name="region" class="form-select reserva-input">
+              <option value="">Seleccionar región</option>
+              {% for region in regiones %}
+                <option value="{{ region.c_reg }}">{{ region.nom_reg }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          {# ── Comuna ── #}
+          <div class="mb-3">
+            <label class="form-label reserva-label" for="comuna">Comuna</label>
+            <select id="comuna" name="comuna" class="form-select reserva-input" disabled>
+              <option value="">Primero selecciona una región</option>
+            </select>
+          </div>
+
+          {# ── Consultorio ── #}
+          <div class="mb-3">
+            <label class="form-label reserva-label" for="consultorio">Consultorio</label>
+            <select id="consultorio" name="consultorio" class="form-select reserva-input" disabled>
+              <option value="">Primero selecciona una comuna</option>
+            </select>
+          </div>
+
+          {# ── Doctor ── #}
+          <div class="mb-3">
+            <label class="form-label reserva-label" for="doctor-select">Doctor</label>
+            <select id="doctor-select" name="profesional_id" class="form-select reserva-input" disabled>
+              <option value="">Primero selecciona un consultorio</option>
+            </select>
+            <div id="sin-doctores" class="form-text text-warning d-none">
+              <i class="bi bi-exclamation-circle me-1"></i>
+              No hay doctores con disponibilidad en este consultorio aún.
             </div>
-            <div class="form-group">
-                <label class="lvl-select" for="comuna">Comuna:</label>
-                <select id="comuna" class="form-control" disabled>
-                    <option value="">Seleccione una comuna</option>
-                </select>
+          </div>
+
+          {# ── Fecha disponible ── #}
+          <div class="mb-3">
+            <label class="form-label reserva-label" for="fecha-select">Fecha disponible</label>
+            <select id="fecha-select" class="form-select reserva-input" disabled>
+              <option value="">Primero selecciona un doctor</option>
+            </select>
+            <div id="sin-fechas" class="form-text text-warning d-none">
+              <i class="bi bi-exclamation-circle me-1"></i>
+              Este doctor no tiene fechas disponibles próximas.
             </div>
-            <div class="form-group">
-                <label class="lvl-select" for="consultorio">Consultorio:</label>
-                <select id="consultorio" class="form-control" disabled>
-                    <option value="">Seleccione un consultorio</option>
-                </select>
+          </div>
+
+          {# ── Horario ── #}
+          <div class="mb-3">
+            <label class="form-label reserva-label" for="slot-select">Horario</label>
+            <select id="slot-select" name="slot" class="form-select reserva-input" disabled>
+              <option value="">Primero selecciona una fecha</option>
+            </select>
+            <div id="sin-slots" class="form-text text-warning d-none">
+              <i class="bi bi-exclamation-circle me-1"></i>
+              No quedan horarios disponibles para esta fecha.
             </div>
+          </div>
+
+          {# ── Motivo ── #}
+          <div class="mb-4">
+            <label class="form-label reserva-label" for="motivo">Motivo de consulta</label>
+            <textarea
+              id="motivo"
+              name="motivo"
+              class="form-control reserva-input"
+              rows="3"
+              placeholder="Describe brevemente el motivo de tu consulta"
+            ></textarea>
+          </div>
+
+          <button type="submit" id="btn-reservar" class="btn btn-primary w-100 reserva-btn" disabled>
+            Confirmar reserva
+          </button>
+
         </form>
+
+      </div>
     </div>
 
-    <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const regionSelect = document.getElementById('region');
-        const comunaSelect = document.getElementById('comuna');
-        const consultorioSelect = document.getElementById('consultorio');
+  </div>
+</div>
+{% endblock %}
 
-        regionSelect.addEventListener('change', function() {
-            const regionId = parseInt(this.value);
-            if (regionId) {
-                fetch(`/consultorio/obtener_comunas/${regionId}/`)
-                    .then(response => response.json())
-                    .then(data => {
-                        comunaSelect.innerHTML = '<option value="">Seleccione una comuna</option>';
-                        data.forEach(comuna => {
-                            comunaSelect.innerHTML += `<option value="${comuna.c_com}">${comuna.nom_com}</option>`;
-                        });
-                        comunaSelect.disabled = false;
-                    });
-            } else {
-                comunaSelect.innerHTML = '<option value="">Seleccione una comuna</option>';
-                comunaSelect.disabled = true;
-                consultorioSelect.innerHTML = '<option value="">Seleccione un consultorio</option>';
-                consultorioSelect.disabled = true;
-            }
-        });
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const regionSelect    = document.getElementById('region');
+  const comunaSelect    = document.getElementById('comuna');
+  const consultorioSel  = document.getElementById('consultorio');
+  const doctorSel       = document.getElementById('doctor-select');
+  const fechaSel        = document.getElementById('fecha-select');
+  const slotSel         = document.getElementById('slot-select');
+  const btnReservar     = document.getElementById('btn-reservar');
+  const sinDoctores     = document.getElementById('sin-doctores');
+  const sinFechas       = document.getElementById('sin-fechas');
+  const sinSlots        = document.getElementById('sin-slots');
 
-        comunaSelect.addEventListener('change', function() {
-            const comunaId = this.value;
-            if (comunaId) {
-                fetch(`/consultorio/obtener_consultorios/${comunaId}/`)
-                    .then(response => response.json())
-                    .then(data => {
-                        consultorioSelect.innerHTML = '<option value="">Seleccione un consultorio</option>';
-                        data.forEach(consultorio => {
-                            consultorioSelect.innerHTML += `<option value="${consultorio.objectid}">${consultorio.nombre}</option>`;
-                        });
-                        consultorioSelect.disabled = false;
-                    });
-            } else {
-                consultorioSelect.innerHTML = '<option value="">Seleccione un consultorio</option>';
-                consultorioSelect.disabled = true;
-            }
+  function reset(select, msg) {
+    select.innerHTML = `<option value="">${msg}</option>`;
+    select.disabled  = true;
+  }
+
+  function checkSubmit() {
+    const ok = consultorioSel.value && doctorSel.value &&
+               fechaSel.value && slotSel.value;
+    btnReservar.disabled = !ok;
+  }
+
+  // ── Región → Comuna ──
+  regionSelect.addEventListener('change', function () {
+    reset(comunaSelect,    'Seleccionar comuna');
+    reset(consultorioSel,  'Primero selecciona una comuna');
+    reset(doctorSel,       'Primero selecciona un consultorio');
+    reset(fechaSel,        'Primero selecciona un doctor');
+    reset(slotSel,         'Primero selecciona una fecha');
+    sinDoctores.classList.add('d-none');
+    sinFechas.classList.add('d-none');
+    sinSlots.classList.add('d-none');
+    checkSubmit();
+
+    if (!this.value) return;
+    fetch(`/consultorio/obtener_comunas/${parseInt(this.value)}/`)
+      .then(r => r.json())
+      .then(data => {
+        comunaSelect.innerHTML = '<option value="">Seleccionar comuna</option>';
+        data.forEach(c => {
+          comunaSelect.innerHTML += `<option value="${c.c_com}">${c.nom_com}</option>`;
         });
-    });
-    </script>
-    {% endblock %}
+        comunaSelect.disabled = false;
+      });
+  });
+
+  // ── Comuna → Consultorio ──
+  comunaSelect.addEventListener('change', function () {
+    reset(consultorioSel, 'Seleccionar consultorio');
+    reset(doctorSel,      'Primero selecciona un consultorio');
+    reset(fechaSel,       'Primero selecciona un doctor');
+    reset(slotSel,        'Primero selecciona una fecha');
+    sinDoctores.classList.add('d-none');
+    sinFechas.classList.add('d-none');
+    sinSlots.classList.add('d-none');
+    checkSubmit();
+
+    if (!this.value) return;
+    fetch(`/consultorio/obtener_consultorios/${this.value}/`)
+      .then(r => r.json())
+      .then(data => {
+        consultorioSel.innerHTML = '<option value="">Seleccionar consultorio</option>';
+        data.forEach(c => {
+          consultorioSel.innerHTML += `<option value="${c.objectid}">${c.nombre}</option>`;
+        });
+        consultorioSel.disabled = false;
+      });
+  });
+
+  // ── Consultorio → Doctor ──
+  consultorioSel.addEventListener('change', function () {
+    reset(doctorSel,  'Cargando doctores...');
+    reset(fechaSel,   'Primero selecciona un doctor');
+    reset(slotSel,    'Primero selecciona una fecha');
+    sinDoctores.classList.add('d-none');
+    sinFechas.classList.add('d-none');
+    sinSlots.classList.add('d-none');
+    checkSubmit();
+
+    if (!this.value) return;
+    fetch(`/consultorio/obtener_doctores/?consultorio_id=${this.value}`)
+      .then(r => r.json())
+      .then(data => {
+        if (data.length === 0) {
+          reset(doctorSel, 'Sin doctores disponibles');
+          sinDoctores.classList.remove('d-none');
+        } else {
+          doctorSel.innerHTML = '<option value="">Seleccionar doctor</option>';
+          data.forEach(d => {
+            doctorSel.innerHTML +=
+              `<option value="${d.id}">Dr/a. ${d.nombre} — ${d.especialidad}</option>`;
+          });
+          doctorSel.disabled = false;
+        }
+      });
+  });
+
+  // ── Doctor → Fechas ──
+  doctorSel.addEventListener('change', function () {
+    reset(fechaSel, 'Cargando fechas...');
+    reset(slotSel,  'Primero selecciona una fecha');
+    sinFechas.classList.add('d-none');
+    sinSlots.classList.add('d-none');
+    checkSubmit();
+
+    if (!this.value) return;
+    fetch(`/consultorio/obtener_fechas/?profesional_id=${this.value}`)
+      .then(r => r.json())
+      .then(data => {
+        if (data.length === 0) {
+          reset(fechaSel, 'Sin fechas disponibles');
+          sinFechas.classList.remove('d-none');
+        } else {
+          fechaSel.innerHTML = '<option value="">Seleccionar fecha</option>';
+          data.forEach(f => {
+            // Formatear de YYYY-MM-DD a DD/MM/YYYY para mostrar
+            const [y, m, d] = f.split('-');
+            fechaSel.innerHTML += `<option value="${f}">${d}/${m}/${y}</option>`;
+          });
+          fechaSel.disabled = false;
+        }
+      });
+  });
+
+  // ── Fecha → Slots ──
+  fechaSel.addEventListener('change', function () {
+    reset(slotSel, 'Cargando horarios...');
+    sinSlots.classList.add('d-none');
+    checkSubmit();
+
+    if (!this.value) return;
+    const pid = doctorSel.value;
+    fetch(`/consultorio/obtener_slots/?profesional_id=${pid}&fecha=${this.value}`)
+      .then(r => r.json())
+      .then(data => {
+        if (data.length === 0) {
+          reset(slotSel, 'Sin horarios disponibles');
+          sinSlots.classList.remove('d-none');
+        } else {
+          slotSel.innerHTML = '<option value="">Seleccionar horario</option>';
+          data.forEach(s => {
+            slotSel.innerHTML += `<option value="${s.value}">${s.label}</option>`;
+          });
+          slotSel.disabled = false;
+        }
+      });
+  });
+
+  slotSel.addEventListener('change', checkSubmit);
+});
+</script>
+{% endblock %}

--- a/consultorio/templates/mis_horas.html
+++ b/consultorio/templates/mis_horas.html
@@ -1,0 +1,176 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Historial de citas — Consultorio Digital{% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/principal.css' %}"/>
+{% endblock %}
+
+{% block navbar %}
+  <ul class="navbar-nav me-auto gap-lg-1">
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'principal:principal' %}">Inicio</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white active" href="{% url 'mis_horas' %}">Mis horas</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'consultorio' %}">Reservar hora</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link text-white" href="{% url 'cancelar_hora' %}">Cancelar hora</a>
+    </li>
+  </ul>
+{% endblock %}
+
+{% block content %}
+  <div class="card border-0 shadow-sm rounded-3">
+    <div class="card-body p-4">
+
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+          <h4 class="fw-light mb-0">
+            <i class="bi bi-clock-history me-2 text-primary"></i>Historial de citas
+          </h4>
+          <p class="text-muted small mb-0 mt-1">Citas pasadas, completadas y canceladas</p>
+        </div>
+        {% if page_obj.paginator.count > 0 %}
+          <span class="badge bg-secondary rounded-pill px-3 py-2">
+            {{ page_obj.paginator.count }} registro{% if page_obj.paginator.count != 1 %}s{% endif %}
+          </span>
+        {% endif %}
+      </div>
+
+      {% if page_obj.object_list %}
+        <div class="table-responsive">
+          <table class="table table-hover align-middle mb-0">
+            <thead class="table-light">
+              <tr>
+                <th class="fw-bold">Consultorio</th>
+                <th class="fw-bold">Doctor</th>
+                <th class="fw-bold">Fecha</th>
+                <th class="fw-bold">Hora</th>
+                <th class="fw-bold">Motivo</th>
+                <th class="fw-bold">Estado</th>
+                <th class="fw-bold">Seguimiento</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for reserva in page_obj %}
+                <tr>
+                  <td>
+                    <i class="bi bi-building me-1 text-muted"></i>
+                    {{ reserva.consultorio.nombre }}
+                  </td>
+                  <td>
+                    {% if reserva.profesional %}
+                      <i class="bi bi-person-badge me-1 text-muted"></i>
+                      Dr/a. {{ reserva.profesional.usuario.nombre }} {{ reserva.profesional.usuario.apellido }}
+                      <br>
+                      <small class="text-muted">{{ reserva.profesional.especialidad }}</small>
+                    {% else %}
+                      <span class="text-muted">—</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <i class="bi bi-calendar3 me-1 text-muted"></i>
+                    {{ reserva.fecha_reserva|date:"d-m-Y" }}
+                  </td>
+                  <td>
+                    <i class="bi bi-clock me-1 text-muted"></i>
+                    {{ reserva.fecha_reserva|date:"H:i" }}
+                  </td>
+                  <td>{{ reserva.motivo }}</td>
+                  <td>
+                    {% if reserva.estado == "confirmada" %}
+                      <span class="badge badge-estado bg-confirmado">Confirmada</span>
+                    {% elif reserva.estado == "pendiente" %}
+                      <span class="badge badge-estado bg-pendiente">Pendiente</span>
+                    {% elif reserva.estado == "completada" %}
+                      <span class="badge badge-estado bg-completada">Completada</span>
+                    {% elif reserva.estado == "seguimiento" %}
+                      <span class="badge badge-estado bg-seguimiento">Seguimiento</span>
+                    {% elif reserva.estado == "cancelada" %}
+                      <span class="badge badge-estado bg-secondary">Cancelada</span>
+                    {% elif reserva.estado == "no_asistio" %}
+                      <span class="badge badge-estado bg-no-asistio">No asistió</span>
+                    {% else %}
+                      <span class="badge badge-estado bg-secondary">{{ reserva.estado }}</span>
+                    {% endif %}
+                    {% if reserva.notas_doctor %}
+                      <div class="small text-muted mt-1 fst-italic">
+                        <i class="bi bi-info-circle me-1"></i>{{ reserva.notas_doctor }}
+                      </div>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if reserva.fecha_seguimiento %}
+                      <i class="bi bi-calendar-check me-1 text-muted"></i>
+                      {{ reserva.fecha_seguimiento|date:"d-m-Y" }}
+                    {% else %}
+                      <span class="text-muted">—</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+        {# Paginación #}
+        {% if page_obj.has_other_pages %}
+          <nav class="mt-4 d-flex justify-content-center" aria-label="Paginación">
+            <ul class="pagination pagination-sm mb-0">
+
+              {% if page_obj.has_previous %}
+                <li class="page-item">
+                  <a class="page-link" href="?page={{ page_obj.previous_page_number }}">
+                    <i class="bi bi-chevron-left"></i>
+                  </a>
+                </li>
+              {% else %}
+                <li class="page-item disabled">
+                  <span class="page-link"><i class="bi bi-chevron-left"></i></span>
+                </li>
+              {% endif %}
+
+              {% for num in page_obj.paginator.page_range %}
+                {% if page_obj.number == num %}
+                  <li class="page-item active">
+                    <span class="page-link">{{ num }}</span>
+                  </li>
+                {% elif num > page_obj.number|add:"-3" and num < page_obj.number|add:"3" %}
+                  <li class="page-item">
+                    <a class="page-link" href="?page={{ num }}">{{ num }}</a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+
+              {% if page_obj.has_next %}
+                <li class="page-item">
+                  <a class="page-link" href="?page={{ page_obj.next_page_number }}">
+                    <i class="bi bi-chevron-right"></i>
+                  </a>
+                </li>
+              {% else %}
+                <li class="page-item disabled">
+                  <span class="page-link"><i class="bi bi-chevron-right"></i></span>
+                </li>
+              {% endif %}
+
+            </ul>
+          </nav>
+        {% endif %}
+
+      {% else %}
+        <div class="text-center text-muted py-5">
+          <i class="bi bi-clock-history fs-2 d-block mb-3 opacity-50"></i>
+          <div class="fw-semibold mb-1">Sin historial aún</div>
+          <div class="small">Las citas completadas, pasadas y canceladas aparecerán aquí</div>
+        </div>
+      {% endif %}
+
+    </div>
+  </div>
+{% endblock %}

--- a/consultorio/urls.py
+++ b/consultorio/urls.py
@@ -3,6 +3,12 @@ from . import views
 
 urlpatterns = [
     path("", views.seleccionar_region, name="consultorio"),
+    path("mis_horas", views.mis_horas, name="mis_horas"),
+    path("cancelar_hora", views.cancelar_hora, name="cancelar_hora"),
     path("obtener_comunas/<int:c_reg>/", views.obtener_comunas, name="obtener_comunas"),
     path("obtener_consultorios/<str:c_com>/", views.obtener_consultorios, name="obtener_consultorios"),
+    path("historial_paciente/", views.historial_paciente, name="historial_paciente"),
+    path("obtener_doctores/", views.obtener_doctores, name="obtener_doctores"),
+    path("obtener_fechas/", views.obtener_fechas, name="obtener_fechas"),
+    path("obtener_slots/", views.obtener_slots, name="obtener_slots"),
 ]

--- a/consultorio/views.py
+++ b/consultorio/views.py
@@ -1,21 +1,233 @@
-from django.shortcuts import render
-from django.http import JsonResponse
-from django.contrib.auth.decorators import login_required
+from datetime import datetime, date, timedelta
 
-from .models import Consultorio
+from django.shortcuts import render, redirect
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.contrib.auth.decorators import login_required
+from django.db.models import Min
+from django.utils import timezone
+
+from .models import Consultorio, Reserva, Usuario, Paciente, Profesional, Disponibilidad
+
+# ---------------------------------------------------------------------------
+# NOTAS DE DESARROLLO — restricciones pendientes de producción
+# ---------------------------------------------------------------------------
+# 1. FECHAS EN EL PASADO: actualmente el flujo de reserva (paciente) y la
+#    declaración de disponibilidad (doctor) permiten seleccionar fechas y
+#    horarios pasados. Esto es intencional para facilitar pruebas.
+#    En producción se deberá validar que fecha_reserva >= now() en la vista
+#    `seleccionar_region` y que la fecha de disponibilidad >= hoy en
+#    `panel_doctor` (action='disponibilidad').
+#
+# 2. CÓDIGO DE CANCELACIÓN: el código de 6 dígitos se genera y muestra
+#    directamente en pantalla. En producción debería enviarse al correo
+#    registrado del paciente y no mostrarse en la interfaz.
+# ---------------------------------------------------------------------------
 
 
 @login_required(login_url='/login/')
 def seleccionar_region(request):
+    if request.method == 'POST':
+        consultorio_id = request.POST.get('consultorio')
+        profesional_id = request.POST.get('profesional_id')
+        motivo         = request.POST.get('motivo', '').strip()
+        slot           = request.POST.get('slot')  # "YYYY-MM-DD HH:MM"
+
+        try:
+            fecha_reserva = datetime.strptime(slot, "%Y-%m-%d %H:%M")
+            if timezone.is_naive(fecha_reserva):
+                fecha_reserva = timezone.make_aware(fecha_reserva)
+
+            u = request.user
+            usuario, _ = Usuario.objects.get_or_create(
+                rut=u.username,
+                defaults={
+                    'nombre'           : u.first_name or u.username,
+                    'apellido'         : u.last_name or '',
+                    'fecha_nacimiento' : date.today(),
+                    'correo'           : u.email or '',
+                },
+            )
+            paciente, _ = Paciente.objects.get_or_create(
+                usuario=usuario,
+                defaults={'ingreso': date.today()},
+            )
+            consultorio  = Consultorio.objects.get(objectid=consultorio_id)
+            profesional  = Profesional.objects.select_related('usuario').get(id=profesional_id)
+
+            # Verificar que el slot sigue disponible (evitar doble reserva)
+            slot_tomado = Reserva.objects.filter(
+                profesional=profesional,
+                fecha_reserva=fecha_reserva,
+            ).exclude(estado='cancelada').exists()
+
+            if not slot_tomado:
+                Reserva.objects.create(
+                    consultorio=consultorio,
+                    paciente=paciente,
+                    profesional=profesional,
+                    fecha_reserva=fecha_reserva,
+                    motivo=motivo,
+                )
+
+            doctor_nombre = f"Dr/a. {profesional.usuario.nombre} {profesional.usuario.apellido}"
+            request.session['reserva_confirmada'] = {
+                'consultorio' : consultorio.nombre,
+                'fecha'       : fecha_reserva.strftime("%d/%m/%Y"),
+                'hora'        : fecha_reserva.strftime("%H:%M"),
+                'doctor'      : doctor_nombre,
+                'ya_tomado'   : slot_tomado,
+            }
+        except Exception as e:
+            print(f"Error al crear reserva: {e}")
+
+        return redirect('principal:principal')
+
     regiones = (
-        Consultorio
-        .objects
-        .values('c_reg', 'nom_reg')
-        .distinct()
+        Consultorio.objects
+        .values('c_reg')
+        .annotate(nom_reg=Min('nom_reg'))
+        .filter(nom_reg__isnull=False)
+        .exclude(nom_reg='')
         .order_by('c_reg')
     )
     return render(request, 'consultorio.html', {'regiones': regiones})
 
+
+# ── Historial de citas de un paciente (para el doctor) ───────────────
+
+@login_required(login_url='/login/')
+def historial_paciente(request):
+    """Devuelve JSON con datos de contacto y citas previas de un paciente,
+    solo visibles para doctores. No incluye información clínica."""
+    paciente_id    = request.GET.get('paciente_id')
+    consultorio_id = request.GET.get('consultorio_id')
+
+    # Solo doctores pueden consultar esto
+    if not Profesional.objects.filter(usuario__rut=request.user.username).exists():
+        return JsonResponse({'error': 'No autorizado'}, status=403)
+
+    try:
+        paciente = Paciente.objects.select_related('usuario').get(id=paciente_id)
+    except Paciente.DoesNotExist:
+        return JsonResponse({'error': 'Paciente no encontrado'}, status=404)
+
+    u = paciente.usuario
+    citas = (
+        Reserva.objects
+        .filter(paciente=paciente, consultorio_id=consultorio_id)
+        .order_by('-fecha_reserva')
+        .values(
+            'id', 'fecha_reserva', 'motivo', 'estado',
+            'notas_doctor', 'fecha_seguimiento',
+        )
+    )
+
+    citas_lista = []
+    for c in citas:
+        citas_lista.append({
+            'fecha'        : c['fecha_reserva'].strftime('%d/%m/%Y %H:%M'),
+            'motivo'       : c['motivo'],
+            'estado'       : c['estado'],
+            'instruccion'  : c['notas_doctor'] or '',
+            'seguimiento'  : c['fecha_seguimiento'].strftime('%d/%m/%Y') if c['fecha_seguimiento'] else '',
+        })
+
+    return JsonResponse({
+        'nombre'   : f"{u.nombre} {u.apellido}",
+        'rut'      : u.rut,
+        'correo'   : u.correo,
+        'telefono' : u.telefono or '',
+        'citas'    : citas_lista,
+    })
+
+
+# ── Endpoints AJAX para el flujo de reserva ──────────────────────────
+
+@login_required(login_url='/login/')
+def obtener_doctores(request):
+    """Doctores que trabajan en un consultorio dado."""
+    consultorio_id = request.GET.get('consultorio_id')
+    if not consultorio_id:
+        return JsonResponse([], safe=False)
+
+    doctores = (
+        Profesional.objects
+        .filter(consultorio_id=consultorio_id)
+        .select_related('usuario')
+        .order_by('usuario__apellido', 'usuario__nombre')
+    )
+    data = [
+        {
+            'id'          : d.id,
+            'nombre'      : f"{d.usuario.nombre} {d.usuario.apellido}",
+            'especialidad': d.especialidad,
+        }
+        for d in doctores
+    ]
+    return JsonResponse(data, safe=False)
+
+
+@login_required(login_url='/login/')
+def obtener_fechas(request):
+    """Fechas con disponibilidad declarada para un profesional (hoy en adelante)."""
+    profesional_id = request.GET.get('profesional_id')
+    if not profesional_id:
+        return JsonResponse([], safe=False)
+
+    hoy    = timezone.localdate()
+    fechas = (
+        Disponibilidad.objects
+        .filter(profesional_id=profesional_id, fecha__gte=hoy)
+        .values_list('fecha', flat=True)
+        .distinct()
+        .order_by('fecha')
+    )
+    return JsonResponse([str(f) for f in fechas], safe=False)
+
+
+@login_required(login_url='/login/')
+def obtener_slots(request):
+    """Slots de 30 min libres para un profesional en una fecha."""
+    profesional_id = request.GET.get('profesional_id')
+    fecha_str      = request.GET.get('fecha')
+
+    if not profesional_id or not fecha_str:
+        return JsonResponse([], safe=False)
+
+    try:
+        fecha = datetime.strptime(fecha_str, "%Y-%m-%d").date()
+    except ValueError:
+        return JsonResponse([], safe=False)
+
+    disponibilidades = Disponibilidad.objects.filter(
+        profesional_id=profesional_id,
+        fecha=fecha,
+    )
+
+    # Generar todos los slots posibles (bloques de 30 min)
+    all_slots = []
+    for disp in disponibilidades:
+        current = datetime.combine(fecha, disp.hora_inicio)
+        end     = datetime.combine(fecha, disp.hora_fin)
+        while current < end:
+            all_slots.append(current)
+            current += timedelta(minutes=30)
+
+    # Slots ya ocupados
+    taken_qs = (
+        Reserva.objects
+        .filter(profesional_id=profesional_id, fecha_reserva__date=fecha)
+        .exclude(estado='cancelada')
+        .values_list('fecha_reserva', flat=True)
+    )
+    taken_times = {timezone.localtime(dt).strftime("%H:%M") for dt in taken_qs}
+
+    free = [
+        {'value': s.strftime("%Y-%m-%d %H:%M"), 'label': s.strftime("%H:%M")}
+        for s in all_slots
+        if s.strftime("%H:%M") not in taken_times
+    ]
+    return JsonResponse(free, safe=False)
 
 @login_required(login_url='/login/')
 def obtener_comunas(request, c_reg):
@@ -29,7 +241,6 @@ def obtener_comunas(request, c_reg):
     )
     return JsonResponse(list(comunas), safe=False)
 
-
 @login_required(login_url='/login/')
 def obtener_consultorios(request, c_com):
     consultorios = (
@@ -39,3 +250,141 @@ def obtener_consultorios(request, c_com):
         .values()
     )
     return JsonResponse(list(consultorios), safe=False)
+
+# Create your views here.
+def home(request: HttpRequest):
+    return render(
+        request = request, 
+        template_name = "consultorio.html", 
+        context = {"title": "Página principal del consultorio"}
+    )
+
+@login_required(login_url='/login/')
+def mis_horas(request: HttpRequest):
+    from django.core.paginator import Paginator
+
+    try:
+        from django.db.models import Q
+        hoy = timezone.localdate()
+        # Historial: todo lo que NO está en "Próximas citas"
+        qs = (
+            Reserva.objects
+            .filter(paciente__usuario__rut=request.user.username)
+            .exclude(
+                Q(estado__in=['pendiente', 'confirmada'],
+                  fecha_reserva__date__gte=hoy)
+                |
+                Q(estado='seguimiento',
+                  fecha_seguimiento__gte=hoy)
+            )
+            .select_related('consultorio', 'profesional__usuario')
+            .order_by('-fecha_reserva')
+        )
+    except Exception:
+        qs = Reserva.objects.none()
+
+    paginator = Paginator(qs, 15)
+    page_obj  = paginator.get_page(request.GET.get('page'))
+
+    return render(
+        request=request,
+        template_name="mis_horas.html",
+        context={"title": "Historial de citas", "page_obj": page_obj},
+    )
+
+@login_required(login_url='/login/')
+def reservar_hora(request: HttpRequest):
+    return render(
+        request = request, 
+        template_name = "reservar_hora.html", 
+        context = {"title": "Reservar hora"}
+    )
+
+@login_required(login_url='/login/')
+def cancelar_hora(request: HttpRequest):
+    import random
+
+    if request.method == 'POST':
+        action = request.POST.get('action')
+
+        # ── Paso 1: selección de cita → generar código y guardarlo en sesión ──
+        if action == 'seleccionar':
+            reserva_id = request.POST.get('reserva_id')
+            if reserva_id:
+                codigo = f"{random.randint(0, 999999):06d}"
+                request.session['cancelacion'] = {
+                    'reserva_id': reserva_id,
+                    'codigo'    : codigo,
+                }
+            return redirect('cancelar_hora')
+
+        # ── Limpiar sesión → volver al paso 1 ──
+        if action == 'limpiar':
+            request.session.pop('cancelacion', None)
+            request.session.pop('codigo_incorrecto', None)
+            return redirect('cancelar_hora')
+
+        # ── Paso 2: verificar código → cancelar o rechazar ──
+        if action == 'confirmar':
+            cancelacion  = request.session.get('cancelacion', {})
+            confirmar_id = request.POST.get('confirmar_reserva_id')
+            codigo_input = request.POST.get('codigo', '').strip()
+            motivo_can   = request.POST.get('motivo_cancelacion', '').strip()
+
+            if (
+                str(cancelacion.get('reserva_id')) == str(confirmar_id)
+                and cancelacion.get('codigo') == codigo_input
+            ):
+                try:
+                    reserva = Reserva.objects.get(
+                        id=confirmar_id,
+                        paciente__usuario__rut=request.user.username,
+                    )
+                    reserva.estado             = 'cancelada'
+                    reserva.motivo_cancelacion = motivo_can or None
+                    reserva.save()
+                except Reserva.DoesNotExist:
+                    pass
+                request.session.pop('cancelacion', None)
+                request.session['reserva_cancelada'] = True
+                return redirect('principal:principal')
+            else:
+                # Código incorrecto: volver al paso 2 con error
+                request.session['codigo_incorrecto'] = True
+                return redirect('cancelar_hora')
+
+    # ── GET: renderizar según estado de sesión ──
+    cancelacion       = request.session.get('cancelacion')
+    codigo_incorrecto = request.session.pop('codigo_incorrecto', False)
+
+    try:
+        reservas_activas = (
+            Reserva.objects
+            .filter(
+                paciente__usuario__rut=request.user.username,
+                estado__in=['pendiente', 'confirmada'],
+            )
+            .select_related('consultorio', 'profesional__usuario')
+            .order_by('fecha_reserva')
+        )
+    except Exception:
+        reservas_activas = []
+
+    reserva_seleccionada = None
+    codigo_generado      = None
+
+    if cancelacion:
+        rid = cancelacion.get('reserva_id')
+        reserva_seleccionada = Reserva.objects.filter(
+            id=rid,
+            paciente__usuario__rut=request.user.username,
+        ).select_related('consultorio', 'profesional__usuario').first()
+        codigo_generado = cancelacion.get('codigo')
+
+    return render(request, 'cancelar_hora.html', {
+        'title'               : 'Cancelar hora',
+        'reservas_activas'    : reservas_activas,
+        'reserva_seleccionada': reserva_seleccionada,
+        'codigo_generado'     : codigo_generado,
+        'codigo_incorrecto'   : codigo_incorrecto,
+    })

--- a/principal/templates/principal.html
+++ b/principal/templates/principal.html
@@ -1,29 +1,255 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}
-    Página principal del Consultorio Digital
-{% endblock %}
+{% block title %}Inicio — Consultorio Digital{% endblock %}
 
 {% block extra_css %}
-    <link rel="stylesheet" href="{% static 'css/principal.css' %}" rel="stylesheet"/>
+  <link rel="stylesheet" href="{% static 'css/principal.css' %}"/>
 {% endblock %}
 
 {% block navbar %}
-    <ul class="navbar-nav">
-        <li class="nav-item active">
-            <a class="nav-link" href="{% url 'principal:principal' %}">Página principal</a>
-        </li>
-    </ul>
+  <ul class="navbar-nav me-auto gap-lg-1">
+    {% if user.is_authenticated %}
+      <li class="nav-item">
+        <a class="nav-link text-white active" href="{% url 'principal:principal' %}">Inicio</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" href="{% url 'mis_horas' %}">Mis horas</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" href="{% url 'consultorio' %}">Reservar hora</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" href="{% url 'cancelar_hora' %}">Cancelar hora</a>
+      </li>
+    {% else %}
+      <li class="nav-item">
+        <a class="nav-link text-white active" href="{% url 'principal:principal' %}">Inicio</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" href="{% url 'registro' %}">Crea tu cuenta</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" href="{% url 'login' %}">Ingresa</a>
+      </li>
+    {% endif %}
+  </ul>
 {% endblock %}
 
 {% block content %}
-    {% if user.is_authenticated %}
-        <h1 class="welcome-txt">¡Bienvenido, {{user.first_name}}!</h1>
-    {% else %}
-        <h1 class="welcome-txt">¡Bienvenido a Consultorio Digital!</h1>
-    {% endif %}
-{% endblock %}
 
-{% block extrascripts %}
+  {# ── Header de bienvenida ── #}
+  {% if user.is_authenticated %}
+    <div class="mb-4 text-center">
+      <h1 class="fw-light mb-1">¡Bienvenido, {{ user.first_name }}!</h1>
+      <p class="text-muted fs-5 fw-light">Aquí puedes ver y gestionar tus citas médicas</p>
+    </div>
+
+    {% if confirmacion %}
+    <div class="alert {% if confirmacion.ya_tomado %}alert-warning{% else %}alert-success{% endif %} alert-dismissible fade show d-flex gap-3 align-items-start mb-4" role="alert">
+      <i class="bi {% if confirmacion.ya_tomado %}bi-exclamation-triangle-fill text-warning{% else %}bi-check-circle-fill text-success{% endif %} fs-4 mt-1"></i>
+      <div>
+        {% if confirmacion.ya_tomado %}
+          <strong>El horario ya fue tomado.</strong><br>
+          <span class="small">Por favor intenta reservar otro horario disponible.</span>
+        {% else %}
+          <strong>¡Cita agendada con éxito!</strong><br>
+          <span class="small">
+            <i class="bi bi-hospital me-1"></i>{{ confirmacion.consultorio }}<br>
+            <i class="bi bi-person-badge me-1"></i>{{ confirmacion.doctor }}<br>
+            <i class="bi bi-calendar3 me-1"></i>{{ confirmacion.fecha }}
+            &nbsp;<i class="bi bi-clock me-1"></i>{{ confirmacion.hora }}
+          </span>
+        {% endif %}
+      </div>
+      <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+    </div>
+    {% endif %}
+
+    <div class="card border-0 shadow-sm rounded-3 mb-4">
+      <div class="card-body p-4">
+
+        <div class="d-flex justify-content-between align-items-start mb-2">
+          <div>
+            <h5 class="fw-light mb-1">
+              <span class="badge bg-primary rounded-circle me-2 d-inline-flex align-items-center justify-content-center" style="width:22px;height:22px;">
+                <i class="bi bi-calendar2 small"></i>
+              </span>
+              Próximas citas
+            </h5>
+            <p class="text-muted small mb-0">
+              Citas activas con fecha pendiente
+            </p>
+          </div>
+          <a href="{% url 'consultorio' %}" class="btn btn-primary btn-nueva-cita">
+            + Nueva Cita
+          </a>
+        </div>
+
+        {# Tabla de citas #}
+        <div class="table-responsive">
+          <table class="table table-hover align-middle mb-0">
+            <thead class="table-light">
+              <tr>
+                <th class="fw-bold">Consultorio</th>
+                <th class="fw-bold">Doctor</th>
+                <th class="fw-bold">Fecha</th>
+                <th class="fw-bold">Hora</th>
+                <th class="fw-bold">Motivo</th>
+                <th class="fw-bold">Ubicación</th>
+                <th class="fw-bold">Estado</th>
+                <th class="fw-bold">Seguimiento</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% if reservas %}
+                {% for reserva in reservas %}
+                  <tr>
+                    <td>
+                      <i class="bi bi-building me-1 text-muted"></i>
+                      {{ reserva.consultorio.nombre }}
+                    </td>
+                    <td>
+                      {% if reserva.profesional %}
+                        <i class="bi bi-person-badge me-1 text-muted"></i>
+                        Dr/a. {{ reserva.profesional.usuario.nombre }} {{ reserva.profesional.usuario.apellido }}
+                        <br>
+                        <small class="text-muted">{{ reserva.profesional.especialidad }}</small>
+                      {% else %}
+                        <span class="text-muted">—</span>
+                      {% endif %}
+                    </td>
+                    <td>
+                      <i class="bi bi-calendar3 me-1 text-muted"></i>
+                      {{ reserva.fecha_reserva|date:"d-m-Y" }}
+                    </td>
+                    <td>
+                      <i class="bi bi-clock me-1 text-muted"></i>
+                      {{ reserva.fecha_reserva|date:"H:i" }}
+                    </td>
+                    <td>{{ reserva.motivo }}</td>
+                    <td>
+                      <a href="https://www.google.com/maps?q={{ reserva.consultorio.latitud }},{{ reserva.consultorio.longitud }}"
+                         target="_blank"
+                         rel="noopener"
+                         class="text-primary text-decoration-none">
+                        {{ reserva.consultorio.direccion }}
+                      </a>
+                    </td>
+                    <td>
+                      {% if reserva.estado == "confirmada" %}
+                        <span class="badge badge-estado bg-confirmado">Confirmada</span>
+                      {% elif reserva.estado == "pendiente" %}
+                        <span class="badge badge-estado bg-pendiente">Pendiente</span>
+                      {% elif reserva.estado == "completada" %}
+                        <span class="badge badge-estado bg-completada">Completada</span>
+                      {% elif reserva.estado == "seguimiento" %}
+                        <span class="badge badge-estado bg-seguimiento">Seguimiento</span>
+                      {% elif reserva.estado == "cancelada" %}
+                        <span class="badge badge-estado bg-secondary">Cancelada</span>
+                      {% elif reserva.estado == "no_asistio" %}
+                        <span class="badge badge-estado bg-no-asistio">No asistió</span>
+                      {% else %}
+                        <span class="badge badge-estado bg-secondary">{{ reserva.estado }}</span>
+                      {% endif %}
+                      {% if reserva.notas_doctor %}
+                        <div class="small text-muted mt-1 fst-italic">
+                          <i class="bi bi-info-circle me-1"></i>{{ reserva.notas_doctor }}
+                        </div>
+                      {% endif %}
+                    </td>
+                    <td>
+                      {% if reserva.fecha_seguimiento %}
+                        <i class="bi bi-calendar-check me-1 text-muted"></i>
+                        {{ reserva.fecha_seguimiento|date:"d-m-Y" }}
+                      {% else %}
+                        <span class="text-muted">—</span>
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              {% else %}
+                <tr>
+                  <td colspan="8" class="text-center text-muted py-5">
+                    <i class="bi bi-calendar-check fs-2 d-block mb-3 text-primary opacity-50"></i>
+                    <div class="fw-semibold mb-1">No tienes citas próximas</div>
+                    <div class="small mb-3">Agenda una cita con tu médico cuando la necesites</div>
+                    <a href="{% url 'consultorio' %}" class="btn btn-primary btn-sm">+ Reservar cita</a>
+                  </td>
+                </tr>
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="row g-4">
+
+      {# — Información importante — #}
+      <div class="col-12 col-md-6">
+        <div class="card border-0 shadow-sm rounded-3 h-100">
+          <div class="card-body p-4">
+            <h5 class="fw-semibold mb-3">Información importante</h5>
+            <ul class="list-unstyled mb-0 info-list">
+              <li>
+                <i class="bi bi-clock-history text-primary me-2"></i>
+                Llega 15 minutos antes de tu cita
+              </li>
+              <li>
+                <i class="bi bi-person-vcard text-primary me-2"></i>
+                Trae tu carnet de identidad y documentos médicos
+              </li>
+              <li>
+                <i class="bi bi-calendar-x text-primary me-2"></i>
+                Si necesitas cancelar, hazlo con 24 horas de anticipación
+              </li>
+              <li>
+                <i class="bi bi-check-circle text-primary me-2"></i>
+                El plazo máximo para una confirmación de cita es de 24 horas
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {# — Contacto de emergencia — #}
+      <div class="col-12 col-md-6">
+        <div class="card border-0 shadow-sm rounded-3 h-100">
+          <div class="card-body p-4">
+            <h5 class="fw-semibold mb-3">
+              🚨 Contacto de emergencia
+            </h5>
+            <ul class="list-unstyled mb-0 info-list">
+              <li>
+                <i class="bi bi-telephone text-dark me-2"></i>
+                Teléfono: +56 2 2345 6789
+              </li>
+              <li>
+                <i class="bi bi-envelope text-dark me-2"></i>
+                Email:
+                <a href="mailto:contacto@consultoriodigital.cl" class="text-primary">
+                  contacto@consultoriodigital.cl
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+    </div>{# /row #}
+
+  {% else %}
+    {# ── Usuario no autenticado ── #}
+    <div class="text-center py-5">
+      <h1 class="fw-light mb-3">¡Bienvenido a ConsultorioDigital!</h1>
+      <p class="text-muted fs-5 mb-4">
+        Gestiona tus citas médicas de forma simple y rápida
+      </p>
+      <a href="{% url 'login' %}" class="btn btn-primary me-2">Iniciar sesión</a>
+      <a href="{% url 'registro' %}" class="btn btn-outline-primary">Crear cuenta</a>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/principal/views.py
+++ b/principal/views.py
@@ -1,10 +1,48 @@
-from django.shortcuts import render
-from django.http import HttpRequest, HttpResponse
+# principal/views.py
+from django.shortcuts import render, redirect
+from django.http import HttpRequest
+from django.db.models import Q
+from django.utils import timezone
+from consultorio.models import Reserva, Profesional
 
-# Create your views here.
 def home(request: HttpRequest):
+    if not request.user.is_authenticated:
+        return redirect('login')
+
+    if Profesional.objects.filter(usuario__rut=request.user.username).exists():
+        return redirect('panel_doctor')
+
+    reservas = []
+
+    if request.user.is_authenticated:
+        try:
+            hoy = timezone.localdate()
+            reservas = (
+                Reserva.objects
+                .filter(paciente__usuario__rut=request.user.username)
+                .filter(
+                    # Citas activas con fecha de hoy en adelante
+                    Q(estado__in=['pendiente', 'confirmada'],
+                      fecha_reserva__date__gte=hoy)
+                    |
+                    # Seguimientos con fecha de seguimiento pendiente
+                    Q(estado='seguimiento',
+                      fecha_seguimiento__gte=hoy)
+                )
+                .select_related('consultorio', 'profesional__usuario')
+                .order_by('fecha_reserva')
+            )
+        except Exception:
+            reservas = []
+
+    confirmacion = request.session.pop('reserva_confirmada', None)
+
     return render(
-        request = request, 
-        template_name = "principal.html", 
-        context = {"title": "Página principal"}
+        request=request,
+        template_name="principal.html",
+        context={
+            "title"       : "Página principal",
+            "reservas"    : reservas,
+            "confirmacion": confirmacion,
+        }
     )

--- a/static/css/mis_horas.css
+++ b/static/css/mis_horas.css
@@ -1,0 +1,77 @@
+.container {
+    margin-top: 50px;
+}
+
+h2 {
+    text-align: center;
+    color: #343a40;
+}
+
+.table {
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: 1rem;
+    background-color: transparent;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: 0.75rem;
+    vertical-align: top;
+    border-top: 1px solid #dee2e6;
+}
+
+.table thead th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #dee2e6;
+    background-color: #343a40;
+    color: #fff;
+}
+
+.table tbody + tbody {
+    border-top: 2px solid #dee2e6;
+}
+
+.table-bordered {
+    border: 1px solid #dee2e6;
+}
+
+.table-bordered th,
+.table-bordered td {
+    border: 1px solid #dee2e6;
+}
+
+.table-bordered thead th,
+.table-bordered thead td {
+    border-bottom-width: 2px;
+}
+
+/* Zebra-striping for better readability */
+.table-striped tbody tr:nth-of-type(odd) {
+    background-color: #f2f2f2;
+}
+
+/* Hover effect */
+.table-hover tbody tr:hover {
+    background-color: #e9ecef;
+}
+
+/* Center text in table cells */
+.table th,
+.table td {
+    text-align: center;
+}
+
+/* Add padding to the table */
+.table {
+    margin: 20px auto;
+    width: 80%;
+}
+
+/* Responsive table */
+@media (max-width: 768px) {
+    .table {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Resumen

Primera iteración funcional del flujo de reserva, visualización y cancelación de horas para el paciente (EDT 4.7 — Integración Frontend-Backend). **Avanza, sin cerrar, los issues #4, #5 y #6** (siguen `estado:parcial`).

## Backend

- **`consultorio/views.py`**: incorpora el flujo completo del paciente:
  - `seleccionar_region` (ya existía) ahora muestra el formulario base.
  - Endpoints AJAX en cascada para autocompletar el formulario:
    - `obtener_comunas(c_reg)` (ya existía)
    - `obtener_consultorios(c_com)` (ya existía)
    - `obtener_doctores(c_consultorio)`
    - `obtener_fechas(c_doctor)` — días con slots libres en los próximos 30 días
    - `obtener_slots(c_doctor, fecha)` — bloques de 30 minutos disponibles
  - `mis_horas`: vista paginada (15 por página) con todas las reservas históricas del paciente.
  - `cancelar_hora`: dos pasos. Primero selección de la cita vigente, luego validación con código de 6 dígitos y motivo en texto libre.
  - `historial_paciente`: endpoint AJAX (sin datos clínicos) para futuras consultas de coordinación.
  - **Verificación server-side anti-doble-reserva** antes de persistir.
- **`consultorio/urls.py`**: rutas para todos los endpoints anteriores.
- **`principal/views.py`**: el home del paciente ahora resuelve un `queryset` con próximas citas (estados `pendiente`/`confirmada`, fecha futura).

## Frontend

- **`principal/templates/principal.html`**: tabla con próximas citas, badges de estado, columna de seguimiento y botón Cancelar.
- **`consultorio/templates/consultorio.html`**: formulario rediseñado con los 6 selects encadenados; el botón Reservar permanece deshabilitado hasta que todos los campos están completos.
- **`consultorio/templates/mis_horas.html`**: historial paginado con badges para todos los estados (pendiente, confirmada, cancelada, completada, no_asistio).
- **`consultorio/templates/cancelar_hora.html`**: dos pasos (selección + verificación con código y motivo).
- **`static/css/mis_horas.css`**: estilos de la tabla.

## Issues afectados

- `#4 PB-05 Reserva de hora médica` — primera iteración funcional, sigue `parcial`.
- `#5 PB-06 Visualización de horas agendadas` — primera iteración funcional, sigue `parcial`.
- `#6 PB-07 Cancelación de hora médica` — primera iteración funcional, sigue `parcial`.

## Notas

- El panel del profesional (issue #11 y siguientes) queda **fuera** de esta entrega y entra cuando esos issues sean abordados.
- El código de verificación se muestra en pantalla en modo desarrollo; el envío real por correo o SMS se planificará junto con el issue de notificaciones.