### PR TITLE
test: pruebas unitarias para vistas con autenticacion requerida

### DIFF
--- a/consultorio/tests.py
+++ b/consultorio/tests.py
@@ -250,3 +250,88 @@ class DisponibilidadModelTests(TestCase):
             fechas_horas,
             sorted(fechas_horas, key=lambda x: (x[0], x[1]))
         )
+
+
+# ---------------------------------------------------------------------------
+# ConsultorioViewAuthTests — vistas que requieren autenticacion
+# ---------------------------------------------------------------------------
+
+class ConsultorioViewAuthTests(TestCase):
+    """Verifica que las vistas protegidas redirigen a login si no hay sesion."""
+
+    def test_seleccionar_region_redirige_sin_login(self):
+        response = self.client.get("/consultorio/")
+        self.assertRedirects(
+            response, "/login/?next=/consultorio/",
+            fetch_redirect_response=False,
+        )
+
+    def test_mis_horas_redirige_sin_login(self):
+        response = self.client.get("/consultorio/mis_horas")
+        self.assertRedirects(
+            response, "/login/?next=/consultorio/mis_horas",
+            fetch_redirect_response=False,
+        )
+
+    def test_cancelar_hora_redirige_sin_login(self):
+        response = self.client.get("/consultorio/cancelar_hora")
+        self.assertRedirects(
+            response, "/login/?next=/consultorio/cancelar_hora",
+            fetch_redirect_response=False,
+        )
+
+    def test_historial_paciente_redirige_sin_login(self):
+        response = self.client.get("/consultorio/historial_paciente/")
+        self.assertRedirects(
+            response, "/login/?next=/consultorio/historial_paciente/",
+            fetch_redirect_response=False,
+        )
+
+
+class ConsultorioViewGetTests(TestCase):
+    """Verifica respuestas GET para usuarios autenticados."""
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        self.user = User.objects.create_user(
+            username="111111118",
+            password="clave_prueba_2026",
+        )
+        self.client.login(username="111111118", password="clave_prueba_2026")
+
+    def test_seleccionar_region_retorna_200(self):
+        response = self.client.get("/consultorio/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_mis_horas_retorna_200(self):
+        response = self.client.get("/consultorio/mis_horas")
+        self.assertEqual(response.status_code, 200)
+
+    def test_cancelar_hora_retorna_200(self):
+        response = self.client.get("/consultorio/cancelar_hora")
+        self.assertEqual(response.status_code, 200)
+
+    def test_obtener_comunas_sin_region_retorna_lista_vacia(self):
+        response = self.client.get("/consultorio/obtener_comunas/99/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_obtener_consultorios_sin_resultados_retorna_lista_vacia(self):
+        response = self.client.get("/consultorio/obtener_consultorios/XXXXX/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_obtener_doctores_sin_consultorio_retorna_lista_vacia(self):
+        response = self.client.get("/consultorio/obtener_doctores/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_obtener_fechas_sin_profesional_retorna_lista_vacia(self):
+        response = self.client.get("/consultorio/obtener_fechas/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_obtener_slots_sin_parametros_retorna_lista_vacia(self):
+        response = self.client.get("/consultorio/obtener_slots/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])

--- a/principal/tests.py
+++ b/principal/tests.py
@@ -1,3 +1,52 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class PrincipalViewTests(TestCase):
+    """Pruebas para la vista principal (landing e inicio autenticado)."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username   = "222222226",
+            password   = "clave_prueba_2026",
+            first_name = "Juan",
+            last_name  = "Soto",
+        )
+
+    def test_landing_retorna_200_sin_login(self):
+        response = self.client.get(reverse("principal:principal"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_landing_contiene_opciones_de_acceso(self):
+        response = self.client.get(reverse("principal:principal"))
+        content  = response.content.decode()
+        # Debe invitar a iniciar sesion o crear cuenta
+        self.assertIn("Iniciar sesi", content)
+
+    def test_inicio_autenticado_retorna_200(self):
+        self.client.login(username="222222226", password="clave_prueba_2026")
+        response = self.client.get(reverse("principal:principal"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_inicio_autenticado_muestra_nombre_usuario(self):
+        self.client.login(username="222222226", password="clave_prueba_2026")
+        response = self.client.get(reverse("principal:principal"))
+        self.assertContains(response, "Juan")
+
+    def test_inicio_autenticado_muestra_tabla_proximas_citas(self):
+        self.client.login(username="222222226", password="clave_prueba_2026")
+        response = self.client.get(reverse("principal:principal"))
+        content  = response.content.decode()
+        self.assertIn("Próximas citas", content)
+
+    def test_context_reservas_presente_para_usuario_autenticado(self):
+        self.client.login(username="222222226", password="clave_prueba_2026")
+        response = self.client.get(reverse("principal:principal"))
+        # La vista debe pasar la variable 'reservas' al template
+        self.assertIn("reservas", response.context)
+
+    def test_reservas_vacias_muestra_mensaje_sin_citas(self):
+        self.client.login(username="222222226", password="clave_prueba_2026")
+        response = self.client.get(reverse("principal:principal"))
+        self.assertContains(response, "No tienes citas")


### PR DESCRIPTION
## Resumen

Agrega pruebas unitarias para las vistas de la aplicacion, verificando control de acceso y respuestas correctas (EDT 5.1 - Prueba Unitaria).

## Cambios

- `consultorio/tests.py`:
  - `ConsultorioViewAuthTests`: redireccion a `/login/?next=...` para las rutas `/consultorio/`, `/mis_horas`, `/cancelar_hora` e `/historial_paciente/` cuando el usuario no esta autenticado
  - `ConsultorioViewGetTests`: respuestas GET 200 para usuario autenticado; endpoints AJAX (obtener_comunas, obtener_consultorios, obtener_doctores, obtener_fechas, obtener_slots) retornan lista vacia cuando no hay datos coincidentes

- `principal/tests.py`:
  - `PrincipalViewTests`: landing publica accesible sin login; inicio autenticado muestra nombre, tabla de proximas citas y variable `reservas` en contexto; mensaje de sin citas cuando no hay reservas activas

Refs #4, #5, #6